### PR TITLE
Add Cargo.toml metadata, README.md; specify macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "amsg-batch"
-version = "0.1.0"
+version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [package]
 name = "amsg-batch"
-version = "0.1.0"
+keywords = ["cli", "messaging", "macos", "apple", "applescript"]
+license = "MIT OR Apache-2.0"
+authors = ["Luis M. B. Varona <lm.varona@outlook.com>"]
+description = "A command-line tool to send bulk texts via Apple Messages on macOS."
+readme = "README.md"
+repository = "https://github.com/Luis-Varona/amsg-batch"
+version = "0.1.0-dev"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# amsg-batch
+
+![Version](https://img.shields.io/badge/version-v0.1.0--dev-pink)
+![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-rebeccapurple)
+[![Build Status](https://github.com/Luis-Varona/amsg-batch/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Luis-Varona/amsg-batch/actions/workflows/ci.yml?query=branch%3Amain)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,10 @@
+// Copyright 2025 Luis M. B. Varona
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use csv::ReaderBuilder;
@@ -12,12 +19,12 @@ const MAX_NUMBER_LENGTH: usize = 15;
 #[derive(Parser)]
 #[command(
     version,
-    about = "Send bulk texts via Apple Messages",
+    about = "Send bulk texts via Apple Messages on macOS",
     long_about = r#"
-Send bulk texts via Apple Messages, with optional personalization. A `.csv` path containing
-recipients and a `.txt` path containing the message are required. Optionally, the service
-(e.g., iMessage or SMS) and a placeholder for recipient names (replaced with a name every
-time it appears in the message) can also be provided.
+Send bulk texts via Apple Messages on macOS, with optional personalization. A `.csv` path
+containing recipients and a `.txt` path containing the message text are required.
+Optionally, the service (e.g., iMessage or SMS) and a placeholder for recipient names
+(replaced with a name every time it appears in the message) can also be provided.
 
 The CSV file of recipients should have no header and either one or two columns. If
 `--placeholder` (or `-p`) is provided, the first should contain recipient names and the


### PR DESCRIPTION
This PR updates the metadata in Cargo.toml (i.e., keywords, license, authors, description, readme, repository, and version), alongside adding a (thus far barebones) README.md It also specifies in the 'about' and 'long_about' parts of the CLI documentation that the tool is meant to be run on macOS.

Forthcoming on the documentation front are function/struct docstrings and a full proper README.md with more description.